### PR TITLE
[codex] add ocow 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ TODO
 
 * 6日: [Hong Kong Open Source Conference (HKOSCon) 2026](https://discourse.opensource.hk/t/call-for-proposals-hong-kong-open-source-conference-2026-6-june-2026/42) ([CFP](https://discourse.opensource.hk/t/call-for-proposals-hong-kong-open-source-conference-2026-6-june-2026/42)) - 香港🇭🇰
 * 18-19日 [KubeCon + CloudNativeCon 印度 2026](https://events.linuxfoundation.org/kubecon-cloudnativecon-india-2026/) - 印度🇮🇳孟买
+* 25日: 第21届开源中国开源世界高峰论坛（OCOW: Open Source China Open Source World）- 北京·中关村展示中心 09:00-17:30
 * 26-27日: [AICon Shanghai 2026](https://aicon.infoq.cn/2026/shanghai/track) - 中国🇨🇳上海虹桥祥源希尔顿酒店
 
 ### 7月


### PR DESCRIPTION
## Summary

Adds the June 25, 2026 第21届开源中国开源世界高峰论坛（OCOW）entry to the 2026 agenda, including venue and event time from the supplied poster.

## Validation

- `git diff --check`

## Notes

This PR intentionally contains only the OCOW agenda entry and excludes other unstaged README changes present in the original checkout.