### PR TITLE
add World Cup final and archive June 2026 events

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ TODO
 
 * 16日: vLLM Meetup 上海「推理的边界 — 从芯片到应用的全栈进化」- 上海·模速空间多功能厅（徐汇区龙台路199号模速空间B区三楼）13:30-17:40
 * 18日: [Vue x Vite 开发者大会 2026](https://vueconf.cn/) - 中国🇨🇳上海
+* 19日: [2026 FIFA 世界杯决赛](https://www.fifa.com/en/tournaments/mens/worldcup/canadamexicousa2026) - 美国🇺🇸纽约/新泽西（MetLife Stadium / New York New Jersey Stadium）15:00 EDT / 7月20日 03:00 北京时间 😊
 * 28-30日：[KubeCon + CloudNativeCon 日本 2026](https://events.linuxfoundation.org/kubecon-cloudnativecon-japan-2026/) 日本🇯🇵横滨
   * 28日（周二）: [CNCF-hosted Co-located Events](https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/co-located-events/) ArgoCon + KeyCloakCon 
 

--- a/README.md
+++ b/README.md
@@ -18,14 +18,6 @@ TODO
 
 <img width="1247" height="699" alt="image" src="https://github.com/user-attachments/assets/64a998f6-a41a-489a-82e3-4716f94c4288" />
 
-### 6月
-
-* 6日: [Hong Kong Open Source Conference (HKOSCon) 2026](https://discourse.opensource.hk/t/call-for-proposals-hong-kong-open-source-conference-2026-6-june-2026/42) ([CFP](https://discourse.opensource.hk/t/call-for-proposals-hong-kong-open-source-conference-2026-6-june-2026/42)) - 香港🇭🇰
-* 11日: [AI Context Series: Singapore](https://www.containerdays.io/past-events/) - 新加坡🇸🇬（约 200+ 技术观众；受众：开发者、平台工程师、技术负责人等）
-* 18-19日 [KubeCon + CloudNativeCon 印度 2026](https://events.linuxfoundation.org/kubecon-cloudnativecon-india-2026/) - 印度🇮🇳孟买
-* 25日: 第21届开源中国开源世界高峰论坛（OCOW: Open Source China Open Source World）- 北京·中关村展示中心 09:00-17:30
-* 26-27日: [AICon Shanghai 2026](https://aicon.infoq.cn/2026/shanghai/track) - 中国🇨🇳上海虹桥祥源希尔顿酒店
-
 ### 7月
 
 * 16日: vLLM Meetup 上海「推理的边界 — 从芯片到应用的全栈进化」- 上海·模速空间多功能厅（徐汇区龙台路199号模速空间B区三楼）13:30-17:40

--- a/archived/2026/README.md
+++ b/archived/2026/README.md
@@ -38,6 +38,14 @@
 * 18-20日: [Open Source Summit North America 2026](https://events.linuxfoundation.org/open-source-summit-north-america-2026/) - 北美🇺🇸
 * 23日: vLLM Meetup 杭州 - 浙江省杭州市余杭区新城路1009号云谷中⼼B1栋2F（ModelScope 杭州开发者中心）
 
+### 6月
+
+* 6日: [Hong Kong Open Source Conference (HKOSCon) 2026](https://discourse.opensource.hk/t/call-for-proposals-hong-kong-open-source-conference-2026-6-june-2026/42) ([CFP](https://discourse.opensource.hk/t/call-for-proposals-hong-kong-open-source-conference-2026-6-june-2026/42)) - 香港🇭🇰
+* 11日: [AI Context Series: Singapore](https://www.containerdays.io/past-events/) - 新加坡🇸🇬（约 200+ 技术观众；受众：开发者、平台工程师、技术负责人等）
+* 18-19日 [KubeCon + CloudNativeCon 印度 2026](https://events.linuxfoundation.org/kubecon-cloudnativecon-india-2026/) - 印度🇮🇳孟买
+* 25日: 第21届开源中国开源世界高峰论坛（OCOW: Open Source China Open Source World）- 北京·中关村展示中心 09:00-17:30
+* 26-27日: [AICon Shanghai 2026](https://aicon.infoq.cn/2026/shanghai/track) - 中国🇨🇳上海虹桥祥源希尔顿酒店
+
 ## 其他链接
 
 - [返回主页](../../README.md)


### PR DESCRIPTION
## Summary

- add the July 19 2026 FIFA World Cup final entry to the July 2026 agenda
- include venue details and Beijing-time kickoff for easier scanning
- archive June 2026 events into `archived/2026/README.md`

## Validation

- `git diff --check`
