### PR TITLE
Add PyCon China 2026 to the agenda

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ TODO
 
 ### 9月
 
+* 5日（周六）: [🐍 PyCon China 2026](https://www.huodongxing.com/event/6870624098800) - 上海长宁·上海对外经贸大学古北校区综合楼 09:00-17:30
 * 6-7日: [AGNTCon + MCPCon China](https://www.lfopensource.cn/mcp-dev-summit-shanghai/) [议题](https://www.lfopensource.cn/mcp-dev-summit-shanghai/program/schedule/) - 中国🇨🇳上海
 * 7日: [OSPOlogy + OSPO Summit China 2026](https://www.lfopensource.cn/kubecon-cloudnativecon-openinfra-summit-pytorch-conference-china/co-located-events/ospology-ospo-summit/) ([提案征集](https://sessionize.com/ospology-opso-summit-china-2026/) 截止 2026年7月12日) - 中国🇨🇳上海
 * **8-9日: [KubeCon + CloudNativeCon + OpenInfra Summit + PyTorch Conference China 2026](https://www.lfasiallc.com/kubecon-cloudnativecon-openinfra-summit-pytorch-conference-china/) - 中国🇨🇳上海** 🌟


### PR DESCRIPTION
## Summary

- add PyCon China 2026 to the September 2026 agenda
- include the registration link, event time, and Shanghai venue

## Why

Registration for PyCon China 2026 is now open, so the conference should be discoverable from the agenda.

## Impact

Readers can find the event date, time, venue, and registration page directly from the README.

## Validation

- `git diff --check`
- verified the final README diff contains only the new PyCon China 2026 entry