### PR TITLE
Archive July 2026 events

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,6 @@ TODO
 
 <img width="1247" height="699" alt="image" src="https://github.com/user-attachments/assets/64a998f6-a41a-489a-82e3-4716f94c4288" />
 
-### 7月
-
-* 16日: vLLM Meetup 上海「推理的边界 — 从芯片到应用的全栈进化」- 上海·模速空间多功能厅（徐汇区龙台路199号模速空间B区三楼）13:30-17:40
-* 18日: [Vue x Vite 开发者大会 2026](https://vueconf.cn/) - 中国🇨🇳上海
-* 19日: [2026 FIFA 世界杯决赛](https://www.fifa.com/en/tournaments/mens/worldcup/canadamexicousa2026) - 美国🇺🇸纽约/新泽西（MetLife Stadium / New York New Jersey Stadium）15:00 EDT / 7月20日 03:00 北京时间 😊
-* 28-30日：[KubeCon + CloudNativeCon 日本 2026](https://events.linuxfoundation.org/kubecon-cloudnativecon-japan-2026/) 日本🇯🇵横滨
-  * 28日（周二）: [CNCF-hosted Co-located Events](https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/co-located-events/) ArgoCon + KeyCloakCon 
-
 ### 8月
 
 * 7-9日: [Community Over Code Asia 2026](https://communityovercode.org/) - 北京市海淀区中关村国家自主创新示范区会议中心

--- a/archived/2026/README.md
+++ b/archived/2026/README.md
@@ -46,6 +46,14 @@
 * 25日: 第21届开源中国开源世界高峰论坛（OCOW: Open Source China Open Source World）- 北京·中关村展示中心 09:00-17:30
 * 26-27日: [AICon Shanghai 2026](https://aicon.infoq.cn/2026/shanghai/track) - 中国🇨🇳上海虹桥祥源希尔顿酒店
 
+### 7月
+
+* 16日: vLLM Meetup 上海「推理的边界 — 从芯片到应用的全栈进化」- 上海·模速空间多功能厅（徐汇区龙台路199号模速空间B区三楼）13:30-17:40
+* 18日: [Vue x Vite 开发者大会 2026](https://vueconf.cn/) - 中国🇨🇳上海
+* 19日: [2026 FIFA 世界杯决赛](https://www.fifa.com/en/tournaments/mens/worldcup/canadamexicousa2026) - 美国🇺🇸纽约/新泽西（MetLife Stadium / New York New Jersey Stadium）15:00 EDT / 7月20日 03:00 北京时间 😊
+* 28-30日：[KubeCon + CloudNativeCon 日本 2026](https://events.linuxfoundation.org/kubecon-cloudnativecon-japan-2026/) 日本🇯🇵横滨
+  * 28日（周二）: [CNCF-hosted Co-located Events](https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/co-located-events/) ArgoCon + KeyCloakCon
+
 ## 其他链接
 
 - [返回主页](../../README.md)


### PR DESCRIPTION
## Summary

- move the July 2026 event section from the main agenda to the 2026 archive
- preserve all July event details and links
- keep the main agenda focused on upcoming events

## Impact

Historical July 2026 events remain available under `archived/2026/README.md`, while `README.md` now starts with August 2026 events.

## Validation

- `git diff --check`
- verified `README.md` no longer contains a July heading
- verified the 2026 archive contains exactly one July heading